### PR TITLE
Added prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ df.explode('values', axis=1)
 # 0  a   1.0   2.0   NaN
 # 1  b  10.0   NaN  20.0
 # 2  c   NaN   2.0   NaN
+df.explode('values', axis=1, record_prefix=True)
+#    s  values.col1  values.col2  values.col3
+# 0  a          1.0          2.0          NaN
+# 1  b         10.0          NaN         20.0
+# 2  c          NaN          2.0          NaN
 
 ```
 

--- a/pandas_explode/__init__.py
+++ b/pandas_explode/__init__.py
@@ -56,7 +56,6 @@ def explode(df, column, axis=0, record_prefix=None, sep='.'):
                         )
 
     def explode_columns(df, column):
-        print(sep)
         return pd.concat((df.drop(columns=column), df[column].apply(pd.Series)\
                         .rename(lambda x: column + sep + x if record_prefix else x, axis='columns')\
                         ), axis=1)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -19,3 +19,19 @@ class ExplodeTests(TestCase):
         })
         exploded_df = explode(df, 'values', axis=1)
         self.assertSequenceEqual(['col1', 'col2', 'col3', 's'], sorted(exploded_df.columns))
+    
+    def test_col_explosion_prefix(self):
+        df = pd.DataFrame({
+            's': ['a', 'b', 'c'],
+            'values': [{'col1': 1, 'col2': 2}, {'col1': 10, 'col3': 20}, {'col2': 2}],
+        })
+        exploded_df = explode(df, 'values', axis=1, record_prefix=True)
+        self.assertSequenceEqual(['s', 'values.col1', 'values.col2', 'values.col3',], sorted(exploded_df.columns))
+    
+    def test_col_explosion_prefix_sep(self):
+        df = pd.DataFrame({
+            's': ['a', 'b', 'c'],
+            'values': [{'col1': 1, 'col2': 2}, {'col1': 10, 'col3': 20}, {'col2': 2}],
+        })
+        exploded_df = explode(df, 'values', axis=1, record_prefix=True, sep='*')
+        self.assertSequenceEqual(['s', 'values*col1', 'values*col2', 'values*col3',], sorted(exploded_df.columns))


### PR DESCRIPTION
Column Headers with prefix support 

* similar to [`json_normalize` function in pandas ](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.io.json.json_normalize.html) to record_prefix. Only when exploding columns.
* Also added support to change the separator.
* Added couple of tests. 

